### PR TITLE
Use single pipeline with different specifications

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,13 +64,14 @@
         <neo4j.version>3.3.1</neo4j.version>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
+        <nlp.version>3.3.1.51.3-SNAPSHOT</nlp.version>
     </properties>
 
     <dependencies>
         <dependency>
             <groupId>com.graphaware.neo4j</groupId>
             <artifactId>nlp</artifactId>
-            <version>3.3.1.51.2</version>
+            <version>${nlp.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -175,7 +176,7 @@
         <dependency>
             <groupId>com.graphaware.neo4j</groupId>
             <artifactId>nlp</artifactId>
-            <version>3.3.1.51.2</version>
+            <version>${nlp.version}</version>
             <type>test-jar</type>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/graphaware/nlp/processor/stanford/PipelineBuilder.java
+++ b/src/main/java/com/graphaware/nlp/processor/stanford/PipelineBuilder.java
@@ -1,5 +1,6 @@
 package com.graphaware.nlp.processor.stanford;
 
+import com.graphaware.nlp.processor.AbstractTextProcessor;
 import edu.stanford.nlp.pipeline.StanfordCoreNLP;
 
 import java.util.ArrayList;
@@ -9,8 +10,6 @@ import java.util.Properties;
 
 public class PipelineBuilder {
 
-    protected static final String CUSTOM_STOP_WORD_LIST = "start,starts,period,periods,a,an,and,are,as,at,be,but,by,for,if,in,into,is,it,no,not,of,o,on,or,such,that,the,their,then,there,these,they,this,to,was,will,with";
-//private static final String CUSTOM_STOP_WORD_LIST = "start,starts,period,periods,a,an,and,are,as,at,but,by,for,if,in,into,it,no,o,on,or,such,that,their,then,there,these,they,this,to,will,with";
     protected final Properties properties = new Properties();
     protected final StringBuilder annotators = new StringBuilder(); //basics annotators
     protected int threadsNumber = 4;
@@ -85,7 +84,7 @@ public class PipelineBuilder {
         checkForExistingAnnotators();
         annotators.append("stopword");
         properties.setProperty("customAnnotatorClass.stopword", StopwordAnnotator.class.getName());
-        properties.setProperty(StopwordAnnotator.STOPWORDS_LIST, CUSTOM_STOP_WORD_LIST);
+        properties.setProperty(StopwordAnnotator.STOPWORDS_LIST, AbstractTextProcessor.DEFAULT_STOP_WORD_LIST);
         return this;
     }
 
@@ -101,7 +100,7 @@ public class PipelineBuilder {
             annotators.append(annoName);
             properties.setProperty("customAnnotatorClass." + annoName, StopwordAnnotator.class.getName());
             if (customStopWordList.startsWith("+")) {
-                stopWordList = CUSTOM_STOP_WORD_LIST + "," + customStopWordList.replace("+,", "").replace("+", "");
+                stopWordList = AbstractTextProcessor.DEFAULT_STOP_WORD_LIST + "," + customStopWordList.replace("+,", "").replace("+", "");
             } else {
                 stopWordList = customStopWordList;
             }
@@ -132,7 +131,7 @@ public class PipelineBuilder {
 
     public static List<String> getDefaultStopwords() {
         List<String> stopwords = new ArrayList<>();
-        Arrays.stream(CUSTOM_STOP_WORD_LIST.split(",")).forEach(s -> {
+        Arrays.stream(AbstractTextProcessor.DEFAULT_STOP_WORD_LIST.split(",")).forEach(s -> {
             stopwords.add(s.trim());
         });
 
@@ -142,7 +141,7 @@ public class PipelineBuilder {
     public static List<String> getCustomStopwordsList(String customStopWordList) {
         String stopWordList;
         if (customStopWordList.startsWith("+")) {
-            stopWordList = CUSTOM_STOP_WORD_LIST + "," + customStopWordList.replace("+,", "").replace("+", "");
+            stopWordList = AbstractTextProcessor.DEFAULT_STOP_WORD_LIST + "," + customStopWordList.replace("+,", "").replace("+", "");
         } else {
             stopWordList = customStopWordList;
         }

--- a/src/test/java/com/graphaware/nlp/integration/StanfordNLPIntegrationTest.java
+++ b/src/test/java/com/graphaware/nlp/integration/StanfordNLPIntegrationTest.java
@@ -4,6 +4,8 @@ import com.graphaware.nlp.NLPIntegrationTest;
 import com.graphaware.nlp.configuration.SettingsConstants;
 import com.graphaware.nlp.processor.PipelineInfo;
 import com.graphaware.nlp.processor.TextProcessor;
+import com.graphaware.nlp.processor.stanford.StanfordTextProcessor;
+import com.graphaware.nlp.util.TestNLPGraph;
 import org.junit.Test;
 import org.neo4j.graphdb.Transaction;
 
@@ -14,40 +16,24 @@ import static org.junit.Assert.*;
 
 public class StanfordNLPIntegrationTest extends NLPIntegrationTest {
 
-    /*@Test
+    @Test
     public void testStanfordAnnotationViaProcedure() {
         clearDb();
-        executeInTransaction("CALL ga.nlp.annotate({text:'Barack Obama is born in Hawaii. He is our president.', textProcessor:'stanford' " +
+        executeInTransaction("CALL ga.nlp.annotate({text:'Barack Obama is born in Hawaii. He is our president.', textProcessor:'"+StanfordTextProcessor.class.getName()+"' " +
                 ", checkLanguage: true, pipeline: 'tokenizer', id:'test'}) YIELD result RETURN result", (result -> {
                     assertTrue(result.hasNext());
         }) );
     }
 
     @Test
-    public void testCustomPipelineIsRegistered() {
-        clearDb();
-        executeInTransaction("CALL ga.nlp.processor.addPipeline({name:\"customie\", stopWords:\"hello,build\", textProcessor:\"stanford\", processingSteps:{tokenize:true, dependency:true, coref: true}})", (result -> {
-            assertTrue(result.hasNext());
-        }));
-        final AtomicBoolean found = new AtomicBoolean(false);
-        List<PipelineInfo> info = getNLPManager().getTextProcessorsManager().getTextProcessor("stanford").getPipelineInfos();
-        info.forEach(pipelineInfo -> {
-            if (pipelineInfo.getName().equals("customie")) {
-                found.set(true);
-            }
-        });
-        assertTrue(found.get());
-    }
-
-    @Test
     public void testCustomPipelineWithoutPhraseStepShouldNotExtractPhrases() {
         clearDb();
-        executeInTransaction("CALL ga.nlp.processor.addPipeline({name:\"customie\", stopWords:\"hello,build\", textProcessor:\"stanford\", processingSteps:{tokenize:true, dependency:true, coref: true}})", (result -> {
+        executeInTransaction("CALL ga.nlp.processor.addPipeline({name:\"customie\", stopWords:\"hello,build\", textProcessor:'"+ StanfordTextProcessor.class.getName() +"', processingSteps:{tokenize:true, dependency:true, coref: true}})", (result -> {
             assertTrue(result.hasNext());
         }));
         String text = "Neo4j is built from the ground up to be a graph database.";
         try (Transaction tx = getDatabase().beginTx()) {
-            getNLPManager().annotateTextAndPersist(text, "test", "stanford", "customie", false, false);
+            getNLPManager().annotateTextAndPersist(text, "test", StanfordTextProcessor.class.getName(), "customie", false, false);
             tx.success();
         }
         executeInTransaction("MATCH (n:Phrase) RETURN n", (result -> {
@@ -59,17 +45,63 @@ public class StanfordNLPIntegrationTest extends NLPIntegrationTest {
     public void testAnnotationWithPipelineFromUserConfig() {
         clearDb();
         getNLPManager().getConfiguration().updateInternalSetting(SettingsConstants.DEFAULT_PIPELINE, TextProcessor.DEFAULT_PIPELINE);
-        executeInTransaction("CALL ga.nlp.processor.addPipeline({name:\"customie\", stopWords:\"hello,build\", textProcessor:\"stanford\", processingSteps:{tokenize:true, dependency:true, coref: true}})", (result -> {
+        executeInTransaction("CALL ga.nlp.processor.addPipeline({name:\"customie\", stopWords:\"hello,build\", textProcessor:'"+ StanfordTextProcessor.class.getName() +"', processingSteps:{tokenize:true, dependency:true, coref: true}})", (result -> {
             assertTrue(result.hasNext());
         }));
         String text = "Neo4j is built from the ground up to be a graph database.";
         try (Transaction tx = getDatabase().beginTx()) {
-            getNLPManager().annotateTextAndPersist(text, "test", "stanford", null, false, false);
+            getNLPManager().annotateTextAndPersist(text, "test", StanfordTextProcessor.class.getName(), null, false, false);
             tx.success();
         }
         executeInTransaction("MATCH (n:Phrase) RETURN n", (result -> {
             assertFalse(result.hasNext());
         }));
-    }*/
+    }
+
+    @Test
+    public void testAnnotationWithPipelineWithoutNERProcessingStep() {
+        clearDb();
+        executeInTransaction("CALL ga.nlp.processor.addPipeline({name:\"customie\", stopWords:\"hello,build\", textProcessor:'"+ StanfordTextProcessor.class.getName() +"', processingSteps:{tokenize:true, ner: false}})", (result -> {
+            assertTrue(result.hasNext());
+        }));
+        String text = "My name is John Doe and I work in Switzerland";
+        executeInTransaction("CALL ga.nlp.annotate({text:'"+text+"', pipeline:'customie', id:'test', checkLanguage:false})", (result -> {
+            assertTrue(result.hasNext());
+        }));
+        TestNLPGraph tester = new TestNLPGraph(getDatabase());
+        tester.assertNodesCount("NER_Person", 0);
+        tester.assertNodesCount("NER_Location", 0);
+        tester.assertNodesCount("NER_O", 0);
+    }
+
+    @Test
+    public void testAnnotationWithPipelineWithNERProcessingStep() {
+        clearDb();
+        executeInTransaction("CALL ga.nlp.processor.addPipeline({name:\"customie\", stopWords:\"hello,build\", textProcessor:'"+ StanfordTextProcessor.class.getName() +"', processingSteps:{tokenize:true, ner: true}})", (result -> {
+            assertTrue(result.hasNext());
+        }));
+        String text = "My name is John Doe and I work in Switzerland";
+        executeInTransaction("CALL ga.nlp.annotate({text:'"+text+"', pipeline:'customie', id:'test', checkLanguage:false})", (result -> {
+            assertTrue(result.hasNext());
+        }));
+        TestNLPGraph tester = new TestNLPGraph(getDatabase());
+        tester.assertNodesCount("NER_Person", 1);
+        tester.assertNodesCount("NER_Location", 1);
+    }
+
+    @Test
+    public void testAnnotationWithPipelineWithExcludedNER() {
+        clearDb();
+        executeInTransaction("CALL ga.nlp.processor.addPipeline({name:\"customie\", stopWords:\"hello,build\", textProcessor:'"+ StanfordTextProcessor.class.getName() +"', processingSteps:{tokenize:true, ner: true}, excludedNER:['LOCATION']})", (result -> {
+            assertTrue(result.hasNext());
+        }));
+        String text = "My name is John Doe and I work in Switzerland";
+        executeInTransaction("CALL ga.nlp.annotate({text:'"+text+"', pipeline:'customie', id:'test', checkLanguage:false})", (result -> {
+            assertTrue(result.hasNext());
+        }));
+        TestNLPGraph tester = new TestNLPGraph(getDatabase());
+        tester.assertNodesCount("NER_Person", 1);
+        tester.assertNodesCount("NER_Location", 0);
+    }
 
 }

--- a/src/test/java/com/graphaware/nlp/processor/TextProcessorTest.java
+++ b/src/test/java/com/graphaware/nlp/processor/TextProcessorTest.java
@@ -271,4 +271,26 @@ public class TextProcessorTest {
         Sentence sentence = annotatedText.getSentences().get(0);
         assertEquals("be", sentence.getTagOccurrence(49).getLemma());
     }
+
+    @Test
+    public void testAnnotateTextWithSpecification() {
+        PipelineSpecification specification = new PipelineSpecification("custom", StanfordTextProcessor.class.getName());
+        specification.getProcessingSteps().put("tokenize", true);
+        specification.getProcessingSteps().put("ner", true);
+        specification.getExcludedNER().add("LOCATION");
+        String text = "My name is John Doe and I work in Switzerland";
+        AnnotatedText annotatedText = textProcessor.annotateText(text, "en", specification);
+        assertEquals(1, annotatedText.getSentences().size());
+        int numberOfLocationEntities = 0;
+        for (Sentence sentence : annotatedText.getSentences()) {
+            for (List<TagOccurrence> olist : sentence.getTagOccurrences().values()) {
+                for (TagOccurrence occurrence : olist ) {
+                    if (occurrence.getElement().getNeAsList().contains("LOCATION")) {
+                        numberOfLocationEntities++;
+                    }
+                }
+            }
+        }
+        assertEquals(0, numberOfLocationEntities);
+    }
 }


### PR DESCRIPTION
This PR makes the TextProcessor initiate a single pipeline with all the annotators. This goes in accordance with the workspace idea avoiding dozens of pipelines to be initiated at startup.

To give an idea of the performance improvement, all stanford tests are running now in **1min30sec** approximately.
  